### PR TITLE
[detox] Add typing for `.not` expectation

### DIFF
--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -309,6 +309,11 @@ declare global {
              */
             toBeVisible(): R;
             /**
+             * Negate the expectation.
+             * @example await expect(element(by.id('UniqueId205'))).not.toBeVisible();
+             */
+            not: Expect<Promise<void>>;
+            /**
              * Expect the view to not be visible.
              * @example await expect(element(by.id('UniqueId205'))).toBeNotVisible();
              */

--- a/types/detox/test/detox-module-tests.ts
+++ b/types/detox/test/detox-module-tests.ts
@@ -39,5 +39,8 @@ describe("Test", () => {
             .toBeVisible()
             .whileElement(by.id("ScrollView630"))
             .scroll(50, "down");
+
+        await expect(element(by.id("element"))).not.toBeVisible();
+        await expect(element(by.id("element"))).not.toExist();
     });
 });


### PR DESCRIPTION
The following:

```
await expect(element(by.id("element"))).not.toBeVisible()
await expect(element(by.id("element"))).not.toExist()
```

Is the updated way to do what had been done with:

```
await expect(element(by.id("element”))).toBeNotVisible()
await expect(element(by.id("element”))).toNotExist()
```

[Those older methods (`.toBeNotVisible()` and `.toNotExist()`) are 
deprecated](https://github.com/wix/Detox/blob/master/docs/APIRef.Expect.md#tobevisible).

I think they still work though, so I left their typings in for now.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wix/Detox/blob/master/docs/APIRef.Expect.md#not
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.